### PR TITLE
Scan repository background task

### DIFF
--- a/scan-agent/scan_agent/server.py
+++ b/scan-agent/scan_agent/server.py
@@ -82,7 +82,7 @@ async def process_job_task(job_id: str):
             return
 
         # Process the job using the worker
-        scan_worker.process_job(job)
+        await scan_worker.process_job(job)
         logger.info(f"Background processing completed for job {job_id}")
 
     except Exception as e:


### PR DESCRIPTION
Refactor scanner to use native `async/await` to resolve `RuntimeError: Already running asyncio in this thread`.

The previous implementation incorrectly called `anyio.run()` within an already active asyncio event loop (e.g., when `process_job` was called from a FastAPI background task), leading to a `RuntimeError`. This change ensures that asynchronous operations are properly awaited within the existing event loop or a new, explicitly managed one for standalone worker execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f357e45-73be-4478-818e-5b29fa8011a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f357e45-73be-4478-818e-5b29fa8011a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

