### PR TITLE
Fix scan target view link

### DIFF
--- a/frontend/src/app/scan-targets/[id]/page.tsx
+++ b/frontend/src/app/scan-targets/[id]/page.tsx
@@ -524,17 +524,6 @@ export default function ScanTargetDetailPage({
                   );
                 })}
 
-                {scanTarget.totalScans > scanTarget.scanJobs.length && (
-                  <div className="text-center pt-4">
-                    <Button asChild variant="outline">
-                      <Link
-                        href={`/scans/${scanTarget.owner}/${scanTarget.repo}`}
-                      >
-                        View All Scans ({scanTarget.totalScans})
-                      </Link>
-                    </Button>
-                  </div>
-                )}
               </div>
             )}
           </CardContent>

--- a/frontend/src/app/scan-targets/page.tsx
+++ b/frontend/src/app/scan-targets/page.tsx
@@ -398,7 +398,7 @@ export default function ScanTargetsPage() {
                         : "Scan Now"}
                     </Button>
                     <Button asChild variant="outline" size="sm">
-                      <Link href={`/scans/${target.owner}/${target.repo}`}>
+                      <Link href={`/scan-targets/${target.id}`}>
                         View Scans
                       </Link>
                     </Button>


### PR DESCRIPTION
Fix incorrect 'View Scans' link for scan targets to direct to the specific target's scans, improving user navigation.

The original 'View Scans' button on the scan targets list page linked to a repository-wide view (`/scans/${owner}/${repo}`), causing confusion as users expected to see scans specific to the selected scan target. This PR updates the link to the correct scan target detail page (`/scan-targets/${target.id}`) and removes a redundant 'View All Scans' button from the scan target detail page that also linked to the generic repository view.

---
<a href="https://cursor.com/background-agent?bcId=bc-0915f0dd-cc43-401b-a5e3-c95fa664320f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0915f0dd-cc43-401b-a5e3-c95fa664320f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

