### PR TITLE
Rename scan worker url to scan agent url

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,10 +3,10 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   env: {
-    SCAN_WORKER_URL:
+    SCAN_AGENT_URL:
       process.env.NODE_ENV === "production"
         ? "https://fortify-1b9n.onrender.com"
-        : process.env.SCAN_WORKER_URL || "http://localhost:8000",
+        : process.env.SCAN_AGENT_URL || "http://localhost:8000",
   },
 };
 

--- a/frontend/src/app/api/jobs/[jobId]/route.ts
+++ b/frontend/src/app/api/jobs/[jobId]/route.ts
@@ -7,7 +7,7 @@ export async function GET(
   try {
     const { jobId } = await params;
     const scanWorkerUrl =
-      process.env.SCAN_WORKER_URL || "http://localhost:8000";
+      process.env.SCAN_AGENT_URL || "http://localhost:8000";
 
     const response = await fetch(`${scanWorkerUrl}/jobs/${jobId}`, {
       method: "GET",

--- a/frontend/src/app/api/projects/[id]/scans/route.ts
+++ b/frontend/src/app/api/projects/[id]/scans/route.ts
@@ -99,7 +99,7 @@ export async function POST(
     });
 
     // Submit job to scan worker
-    const scanWorkerUrl = process.env.SCAN_WORKER_URL || "http://localhost:8000";
+    const scanWorkerUrl = process.env.SCAN_AGENT_URL || "http://localhost:8000";
     
     try {
       const workerResponse = await fetch(`${scanWorkerUrl}/scan/repo`, {

--- a/frontend/src/app/api/scan-targets/[id]/scan/route.ts
+++ b/frontend/src/app/api/scan-targets/[id]/scan/route.ts
@@ -69,7 +69,7 @@ export async function POST(
     // Trigger actual scan worker
     try {
       const scanWorkerUrl =
-        process.env.SCAN_WORKER_URL || "http://localhost:8000";
+        process.env.SCAN_AGENT_URL || "http://localhost:8000";
 
       const response = await fetch(`${scanWorkerUrl}/scan/repo`, {
         method: "POST",


### PR DESCRIPTION
Rename `SCAN_WORKER_URL` to `SCAN_AGENT_URL` for improved naming consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-4110c5f3-d137-4f15-a0ab-a42f5b9e8694">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4110c5f3-d137-4f15-a0ab-a42f5b9e8694">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

