### PR TITLE
Handle scan job result type errors

### DIFF
--- a/scan-agent/scan_agent/utils/queue.py
+++ b/scan-agent/scan_agent/utils/queue.py
@@ -79,7 +79,12 @@ class JobQueue:
         job = self.get_job(job_id)
         if job:
             job.status = JobStatus.COMPLETED
-            job.result = result
+            # Ensure result is JSON-serializable before storing
+            try:
+                job.result = json.loads(json.dumps(result, default=str))
+            except (TypeError, ValueError):
+                # Fallback: convert to string if serialization fails
+                job.result = str(result)
             self.update_job(job)
             # Remove from processing queue
             self.redis.lrem(self.processing_queue, 1, job_id)


### PR DESCRIPTION
Add JSON serialization for scan job results and job queue completion to resolve Prisma P2009 errors.

The Prisma P2009 error "Unable to match input value to any allowed input type for the field" occurred because non-JSON-serializable objects (like datetime instances) were being passed to database JSON fields. This PR introduces a utility to ensure all data is properly serialized before storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-daf5fc00-6007-4c28-9c33-1e67a212583e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-daf5fc00-6007-4c28-9c33-1e67a212583e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

