### PR TITLE
Hide removal button if only one repository

### DIFF
--- a/frontend/src/app/projects/[id]/settings/page.tsx
+++ b/frontend/src/app/projects/[id]/settings/page.tsx
@@ -362,13 +362,15 @@ export default function ProjectSettingsPage({
                     <Button size="sm" variant="outline">
                       Configure
                     </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="text-destructive hover:text-destructive/80"
-                    >
-                      Remove
-                    </Button>
+                    {project.repositories.length > 1 && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="text-destructive hover:text-destructive/80"
+                      >
+                        Remove
+                      </Button>
+                    )}
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
Hide the repository 'Remove' button when only one repository is present to prevent accidental removal of the last repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-faab30cd-e371-48e3-97cf-6adedb419ac5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-faab30cd-e371-48e3-97cf-6adedb419ac5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

