### PR TITLE
Remove add repository button for single repo support

### DIFF
--- a/frontend/src/app/projects/[id]/settings/page.tsx
+++ b/frontend/src/app/projects/[id]/settings/page.tsx
@@ -285,21 +285,13 @@ export default function ProjectSettingsPage({
               <p className="text-muted-foreground mb-4">
                 No repositories configured
               </p>
-              <Button className="bg-primary hover:bg-primary/90">
-                <Github className="h-4 w-4 mr-2" />
-                Add Repository
-              </Button>
             </div>
           ) : (
             <div className="space-y-4">
-              <div className="flex justify-between items-center">
+              <div className="mb-4">
                 <p className="text-sm text-muted-foreground">
                   {project.repositories.length} repositories configured
                 </p>
-                <Button size="sm" className="bg-primary hover:bg-primary/90">
-                  <Github className="h-4 w-4 mr-2" />
-                  Add Repository
-                </Button>
               </div>
               {project.repositories.map((repo) => (
                 <div


### PR DESCRIPTION
Remove "Add Repository" buttons from project settings page because the system now supports only a single repository per project.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0ff920c-c54b-4880-a786-6567f29d3ac2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0ff920c-c54b-4880-a786-6567f29d3ac2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

