### PR TITLE
Fix scan job dashboard time elapsed

### DIFF
--- a/frontend/src/app/jobs/[jobId]/page.tsx
+++ b/frontend/src/app/jobs/[jobId]/page.tsx
@@ -202,6 +202,13 @@ export default function ScanJobPage() {
     const start = new Date(startTime);
     const end = endTime ? new Date(endTime) : new Date();
     const diff = end.getTime() - start.getTime();
+    
+    // Handle negative time differences (clock sync issues)
+    if (diff < 0) {
+      console.warn(`Negative time difference detected: start=${startTime}, end=${endTime || 'now'}, diff=${diff}ms`);
+      return "0s"; // Show 0 seconds for negative differences
+    }
+    
     const seconds = Math.floor(diff / 1000);
     const minutes = Math.floor(seconds / 60);
 

--- a/frontend/src/app/projects/[id]/scans/page.tsx
+++ b/frontend/src/app/projects/[id]/scans/page.tsx
@@ -108,11 +108,18 @@ export default function ProjectScansPage() {
   };
 
   const formatDuration = (startedAt: string | null, finishedAt: string | null) => {
-    if (!startedAt || !finishedAt) return null;
+    if (!startedAt) return null;
     
     const start = new Date(startedAt);
-    const finish = new Date(finishedAt);
+    const finish = finishedAt ? new Date(finishedAt) : new Date();
     const diffMs = finish.getTime() - start.getTime();
+    
+    // Handle negative time differences (clock sync issues)
+    if (diffMs < 0) {
+      console.warn(`Negative time difference detected: start=${startedAt}, end=${finishedAt || 'now'}, diff=${diffMs}ms`);
+      return "0s"; // Show 0 seconds for negative differences
+    }
+    
     const diffMinutes = Math.floor(diffMs / (1000 * 60));
     const diffSeconds = Math.floor((diffMs % (1000 * 60)) / 1000);
     

--- a/frontend/src/app/scans/[owner]/[repo]/page.tsx
+++ b/frontend/src/app/scans/[owner]/[repo]/page.tsx
@@ -154,10 +154,18 @@ function RepositoryScansContent({
   };
 
   const formatDuration = (startedAt?: string, finishedAt?: string) => {
-    if (!startedAt || !finishedAt) return "N/A";
+    if (!startedAt) return "N/A";
+    
     const start = new Date(startedAt);
-    const end = new Date(finishedAt);
+    const end = finishedAt ? new Date(finishedAt) : new Date();
     const diff = end.getTime() - start.getTime();
+    
+    // Handle negative time differences (clock sync issues)
+    if (diff < 0) {
+      console.warn(`Negative time difference detected: start=${startedAt}, end=${finishedAt || 'now'}, diff=${diff}ms`);
+      return "0s"; // Show 0 seconds for negative differences
+    }
+    
     const minutes = Math.floor(diff / 60000);
     const seconds = Math.floor((diff % 60000) / 1000);
     return `${minutes}m ${seconds}s`;

--- a/frontend/src/lib/vulnerability-utils.ts
+++ b/frontend/src/lib/vulnerability-utils.ts
@@ -58,10 +58,18 @@ export function formatDate(dateString: string): string {
 }
 
 export function formatDuration(startedAt?: string, finishedAt?: string): string {
-  if (!startedAt || !finishedAt) return "N/A";
+  if (!startedAt) return "N/A";
+  
   const start = new Date(startedAt);
-  const end = new Date(finishedAt);
+  const end = finishedAt ? new Date(finishedAt) : new Date();
   const diff = end.getTime() - start.getTime();
+  
+  // Handle negative time differences (clock sync issues)
+  if (diff < 0) {
+    console.warn(`Negative time difference detected: start=${startedAt}, end=${finishedAt || 'now'}, diff=${diff}ms`);
+    return "0s"; // Show 0 seconds for negative differences
+  }
+  
   const minutes = Math.floor(diff / 60000);
   const seconds = Math.floor((diff % 60000) / 1000);
   return `${minutes}m ${seconds}s`;

--- a/scan-agent/scan_agent/workers/scanner.py
+++ b/scan-agent/scan_agent/workers/scanner.py
@@ -794,12 +794,14 @@ Please begin the security audit now."""
                     data={
                         "update": {
                             "status": "IN_PROGRESS",
+                            "startedAt": datetime.now(),
                             "data": json.dumps(job.data),
                         },
                         "create": {
                             "id": job.id,
                             "type": "SCAN_REPO",
                             "status": "IN_PROGRESS",
+                            "startedAt": datetime.now(),
                             "data": json.dumps(job.data),
                         },
                     },


### PR DESCRIPTION
Fix incorrect and negative time elapsed in scan job dashboards by setting `startedAt` in the backend and improving frontend duration calculation logic.

The issue was caused by the `startedAt` timestamp not being set when a scan job transitioned to `IN_PROGRESS` in the backend. This led to the frontend using `created_at` or other fallbacks, resulting in incorrect or negative elapsed times. Frontend duration calculation functions were also updated to gracefully handle negative time differences (e.g., due to clock sync issues) and correctly display durations for in-progress jobs.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed4010df-f9ab-47db-872b-3216754c7073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed4010df-f9ab-47db-872b-3216754c7073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

