### PR TITLE
Investigate scan job status mismatch

### DIFF
--- a/scan-agent/JOB_STATUS_FIX_README.md
+++ b/scan-agent/JOB_STATUS_FIX_README.md
@@ -1,0 +1,133 @@
+# Job Status Synchronization Fix
+
+This document explains the job status synchronization issue and how to fix it.
+
+## Problem Description
+
+**Issue**: Scan jobs show as "completed" on the frontend but remain "in progress" in the database.
+
+**Root Cause**: The scanner worker had a bug where database update failures were silently swallowed, but Redis job queue updates still happened. This caused:
+
+1. ✅ Redis shows `COMPLETED` (frontend displays this)
+2. ❌ Database shows `IN_PROGRESS` (actual persistent state)
+
+**Impact**: 
+- Frontend shows misleading job status
+- Database queries show incorrect status
+- Potential data inconsistency issues
+
+## Fix Applied
+
+**File**: `scan-agent/scan_agent/workers/scanner.py`
+
+**Change**: Modified the exception handling in `_process_scan_job` method to re-raise database update failures instead of silently swallowing them.
+
+**Before**:
+```python
+except Exception as update_error:
+    logger.error(f"Failed to update ScanJob status: {update_error}")
+    print(f"❌ Failed to update ScanJob status: {update_error}")
+    # Method continues and returns successfully, causing Redis to be updated
+```
+
+**After**:
+```python
+except Exception as update_error:
+    logger.error(f"Failed to update ScanJob status: {update_error}")
+    print(f"❌ Failed to update ScanJob status: {update_error}")
+    # Re-raise the exception to prevent Redis from being marked as completed
+    # if database update failed
+    raise Exception(f"Database update failed: {update_error}")
+```
+
+**Result**: Now if database update fails, Redis won't be marked as completed either, keeping both in sync.
+
+## Fixing Existing Inconsistent Jobs
+
+### 1. Identify Inconsistent Jobs
+
+Run the diagnostic script to find jobs with mismatched status:
+
+```bash
+cd scan-agent
+python fix_job_status_sync.py
+```
+
+The script will:
+- Scan all jobs in Redis and compare with database status
+- Show detailed analysis of inconsistencies
+- Provide options to fix the issues
+
+### 2. Fix Options
+
+**Option 1**: Dry run analysis
+- Shows what would be fixed without making changes
+- Safe to run anytime
+
+**Option 2**: Automatic fix
+- Updates database status to match Redis status
+- Copies results from Redis to database if missing
+- Sets appropriate timestamps
+
+### 3. Common Inconsistency Patterns
+
+| Redis Status | DB Status | Fix Action |
+|-------------|-----------|------------|
+| `COMPLETED` | `IN_PROGRESS` | Update DB to `COMPLETED`, set `finishedAt` |
+| `FAILED` | `IN_PROGRESS` | Update DB to `FAILED`, copy error message |
+| `CANCELLED` | `IN_PROGRESS` | Update DB to `CANCELLED` |
+
+## Testing the Fix
+
+Verify the fix works correctly:
+
+```bash
+cd scan-agent
+python test_job_status_sync.py
+```
+
+This test:
+- Simulates database update failures
+- Verifies Redis doesn't get marked as completed when DB update fails
+- Tests successful completion path
+- Confirms both systems stay synchronized
+
+## Prevention
+
+The fix prevents future occurrences by:
+
+1. **Proper Exception Propagation**: Database failures now prevent Redis updates
+2. **Fail-Fast Behavior**: If database is unavailable, jobs fail cleanly
+3. **Status Consistency**: Both Redis and database are always in sync
+
+## Monitoring
+
+To monitor for status inconsistencies:
+
+1. **Regular Checks**: Run the diagnostic script periodically
+2. **Logging**: Monitor scan worker logs for database update failures
+3. **Metrics**: Track job completion rates vs. database completion rates
+
+## Recovery Process
+
+If inconsistencies are found:
+
+1. **Immediate**: Run `fix_job_status_sync.py` to sync existing jobs
+2. **Investigation**: Check scan worker logs for database connection issues
+3. **Prevention**: Ensure database is healthy and accessible
+
+## Files Modified/Created
+
+- ✏️  **Modified**: `scan-agent/scan_agent/workers/scanner.py`
+- 🆕 **Created**: `scan-agent/fix_job_status_sync.py` (diagnostic/fix tool)
+- 🆕 **Created**: `scan-agent/test_job_status_sync.py` (test suite)
+- 🆕 **Created**: `scan-agent/JOB_STATUS_FIX_README.md` (this document)
+
+## Future Improvements
+
+Consider these enhancements:
+
+1. **Database Transactions**: Wrap job completion in atomic transactions
+2. **Retry Logic**: Add retry mechanism for database update failures  
+3. **Health Checks**: Add database health monitoring to worker
+4. **Metrics**: Add Prometheus/monitoring for job status consistency

--- a/scan-agent/fix_job_status_sync.py
+++ b/scan-agent/fix_job_status_sync.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Fix job status synchronization between Redis and Database.
+
+This script identifies and fixes jobs where Redis shows COMPLETED 
+but the database shows IN_PROGRESS, which can happen due to database
+update failures that were previously silently swallowed.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime
+from typing import List, Dict, Any
+
+# Add the scan_agent package to the path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from scan_agent.utils.queue import JobQueue
+from scan_agent.utils.database import init_database, get_db, close_database
+from scan_agent.models.job import JobStatus
+
+
+async def find_inconsistent_jobs() -> List[Dict[str, Any]]:
+    """Find jobs where Redis and database status don't match."""
+    print("🔍 Finding jobs with inconsistent status between Redis and Database...")
+    
+    # Initialize database connection
+    await init_database()
+    db = await get_db()
+    
+    # Get job queue
+    job_queue = JobQueue()
+    
+    inconsistent_jobs = []
+    
+    try:
+        # Get all jobs from Redis
+        redis_jobs = job_queue.list_jobs(limit=1000)
+        print(f"📊 Found {len(redis_jobs)} jobs in Redis")
+        
+        for redis_job in redis_jobs:
+            try:
+                # Get corresponding database record
+                db_job = await db.scanjob.find_unique(where={"id": redis_job.id})
+                
+                if db_job:
+                    redis_status = redis_job.status.value
+                    db_status = db_job.status
+                    
+                    if redis_status != db_status:
+                        inconsistent_jobs.append({
+                            "job_id": redis_job.id,
+                            "redis_status": redis_status,
+                            "db_status": db_status,
+                            "created_at": redis_job.created_at.isoformat(),
+                            "updated_at": redis_job.updated_at.isoformat() if redis_job.updated_at else None,
+                            "db_started_at": db_job.startedAt.isoformat() if db_job.startedAt else None,
+                            "db_finished_at": db_job.finishedAt.isoformat() if db_job.finishedAt else None,
+                            "redis_result": bool(redis_job.result),
+                            "db_result": bool(db_job.result),
+                        })
+                        print(f"⚠️  Inconsistent job found: {redis_job.id}")
+                        print(f"   Redis: {redis_status}, Database: {db_status}")
+                else:
+                    # Job exists in Redis but not in database
+                    inconsistent_jobs.append({
+                        "job_id": redis_job.id,
+                        "redis_status": redis_job.status.value,
+                        "db_status": "MISSING",
+                        "created_at": redis_job.created_at.isoformat(),
+                        "updated_at": redis_job.updated_at.isoformat() if redis_job.updated_at else None,
+                        "db_started_at": None,
+                        "db_finished_at": None,
+                        "redis_result": bool(redis_job.result),
+                        "db_result": False,
+                    })
+                    print(f"⚠️  Job missing from database: {redis_job.id}")
+                    
+            except Exception as e:
+                print(f"❌ Error checking job {redis_job.id}: {e}")
+                continue
+                
+    finally:
+        await close_database()
+    
+    return inconsistent_jobs
+
+
+async def fix_inconsistent_job(job_info: Dict[str, Any], dry_run: bool = True) -> bool:
+    """Fix a single inconsistent job."""
+    job_id = job_info["job_id"]
+    redis_status = job_info["redis_status"]
+    db_status = job_info["db_status"]
+    
+    print(f"\n🔧 {'[DRY RUN] ' if dry_run else ''}Fixing job {job_id}")
+    print(f"   Redis: {redis_status}, Database: {db_status}")
+    
+    if dry_run:
+        print(f"   Would update database status from {db_status} to {redis_status}")
+        return True
+        
+    try:
+        await init_database()
+        db = await get_db()
+        
+        if db_status == "MISSING":
+            print(f"   Skipping job {job_id} - missing from database entirely")
+            return False
+            
+        # Update database status to match Redis
+        update_data = {"status": redis_status}
+        
+        # If Redis shows COMPLETED, set finishedAt if not already set
+        if redis_status == "COMPLETED" and not job_info["db_finished_at"]:
+            update_data["finishedAt"] = datetime.now()
+            
+        # If Redis shows IN_PROGRESS, set startedAt if not already set  
+        elif redis_status == "IN_PROGRESS" and not job_info["db_started_at"]:
+            update_data["startedAt"] = datetime.now()
+        
+        await db.scanjob.update(
+            where={"id": job_id},
+            data=update_data
+        )
+        
+        print(f"   ✅ Updated database status to {redis_status}")
+        
+        # Get Redis job result and copy to database if needed
+        job_queue = JobQueue()
+        redis_job = job_queue.get_job(job_id)
+        
+        if redis_job and redis_job.result and not job_info["db_result"]:
+            try:
+                # Copy result from Redis to database
+                await db.scanjob.update(
+                    where={"id": job_id},
+                    data={"result": json.dumps(redis_job.result, default=str)}
+                )
+                print(f"   ✅ Copied result from Redis to database")
+            except Exception as e:
+                print(f"   ⚠️  Failed to copy result: {e}")
+        
+        await close_database()
+        return True
+        
+    except Exception as e:
+        print(f"   ❌ Failed to fix job {job_id}: {e}")
+        await close_database()
+        return False
+
+
+async def main():
+    """Main function."""
+    print("🚀 Job Status Synchronization Fix Tool")
+    print("=" * 50)
+    
+    # Find inconsistent jobs
+    inconsistent_jobs = await find_inconsistent_jobs()
+    
+    if not inconsistent_jobs:
+        print("\n✅ No inconsistent jobs found! All job statuses are synchronized.")
+        return
+        
+    print(f"\n📊 Found {len(inconsistent_jobs)} inconsistent jobs:")
+    print("\nSummary:")
+    
+    status_combos = {}
+    for job in inconsistent_jobs:
+        combo = f"Redis:{job['redis_status']} -> DB:{job['db_status']}"
+        status_combos[combo] = status_combos.get(combo, 0) + 1
+        
+    for combo, count in status_combos.items():
+        print(f"   {combo}: {count} jobs")
+    
+    print("\nDetailed list:")
+    for job in inconsistent_jobs[:10]:  # Show first 10
+        print(f"   {job['job_id']}: Redis={job['redis_status']}, DB={job['db_status']}")
+    
+    if len(inconsistent_jobs) > 10:
+        print(f"   ... and {len(inconsistent_jobs) - 10} more")
+    
+    # Ask user what to do
+    print(f"\n{'='*50}")
+    print("Options:")
+    print("1. Show detailed analysis (dry run)")
+    print("2. Fix all inconsistencies by updating database to match Redis")
+    print("3. Exit without making changes")
+    
+    try:
+        choice = input("\nEnter your choice (1-3): ").strip()
+    except KeyboardInterrupt:
+        print("\n\n👋 Exiting...")
+        return
+        
+    if choice == "1":
+        print("\n🔍 Performing dry run...")
+        fixed_count = 0
+        for job in inconsistent_jobs:
+            success = await fix_inconsistent_job(job, dry_run=True)
+            if success:
+                fixed_count += 1
+        print(f"\n📊 Dry run complete: {fixed_count}/{len(inconsistent_jobs)} jobs would be fixed")
+        
+    elif choice == "2":
+        print(f"\n⚠️  You are about to fix {len(inconsistent_jobs)} inconsistent jobs.")
+        print("This will update the database status to match Redis status.")
+        
+        try:
+            confirm = input("Are you sure you want to proceed? (yes/no): ").strip().lower()
+        except KeyboardInterrupt:
+            print("\n\n👋 Cancelled.")
+            return
+            
+        if confirm in ["yes", "y"]:
+            print("\n🔧 Fixing inconsistent jobs...")
+            fixed_count = 0
+            failed_count = 0
+            
+            for job in inconsistent_jobs:
+                success = await fix_inconsistent_job(job, dry_run=False)
+                if success:
+                    fixed_count += 1
+                else:
+                    failed_count += 1
+                    
+            print(f"\n📊 Fix complete:")
+            print(f"   ✅ Fixed: {fixed_count} jobs")
+            print(f"   ❌ Failed: {failed_count} jobs")
+            print(f"   📊 Total: {len(inconsistent_jobs)} jobs processed")
+            
+            if fixed_count > 0:
+                print(f"\n🎉 Successfully synchronized {fixed_count} job statuses!")
+        else:
+            print("\n👋 Operation cancelled.")
+            
+    else:
+        print("\n👋 Exiting without making changes.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scan-agent/scan_agent/workers/scanner.py
+++ b/scan-agent/scan_agent/workers/scanner.py
@@ -1266,6 +1266,9 @@ Please begin the security audit now."""
             except Exception as update_error:
                 logger.error(f"Failed to update ScanJob status: {update_error}")
                 print(f"❌ Failed to update ScanJob status: {update_error}")
+                # Re-raise the exception to prevent Redis from being marked as completed
+                # if database update failed
+                raise Exception(f"Database update failed: {update_error}")
 
             logger.info(f"Scan completed successfully for job {job.id}")
             logger.debug(f"Final result keys: {list(result.keys())}")

--- a/scan-agent/test_job_status_sync.py
+++ b/scan-agent/test_job_status_sync.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Test script to verify job status synchronization fix works correctly.
+
+This script simulates database update failures to ensure that Redis
+and database status remain synchronized with the new fix.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime
+from unittest.mock import patch, AsyncMock
+
+# Add the scan_agent package to the path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from scan_agent.utils.queue import JobQueue
+from scan_agent.utils.database import init_database, get_db, close_database
+from scan_agent.models.job import Job, JobStatus, JobType
+from scan_agent.workers.scanner import ScanWorker
+
+
+async def test_database_failure_handling():
+    """Test that Redis doesn't get marked as completed when database update fails."""
+    print("🧪 Testing database failure handling...")
+    
+    # Create a test job
+    job_queue = JobQueue()
+    
+    test_job_data = {
+        "repo_url": "https://github.com/test/repo.git",
+        "branch": "main",
+        "claude_cli_args": None,
+        "scan_options": {}
+    }
+    
+    job_id = job_queue.add_job(JobType.SCAN_REPO, test_job_data)
+    print(f"📝 Created test job: {job_id}")
+    
+    # Get the job and set it to IN_PROGRESS (simulate worker picking it up)
+    job = job_queue.get_job(job_id)
+    job.status = JobStatus.IN_PROGRESS
+    job_queue.update_job(job)
+    
+    print(f"🔄 Job status in Redis: {job_queue.get_job_status(job_id).value}")
+    
+    # Initialize database connection
+    await init_database()
+    db = await get_db()
+    
+    try:
+        # Create ScanJob record in database
+        await db.scanjob.create(
+            data={
+                "id": job_id,
+                "type": "SCAN_REPO",
+                "status": "IN_PROGRESS",
+                "startedAt": datetime.now(),
+                "data": json.dumps(test_job_data),
+            }
+        )
+        print(f"💾 Created ScanJob record in database")
+        
+        # Check initial database status
+        db_job = await db.scanjob.find_unique(where={"id": job_id})
+        print(f"💾 Initial database status: {db_job.status}")
+        
+        # Now simulate a database update failure in the scanner worker
+        worker = ScanWorker()
+        
+        # Mock the database update to raise an exception
+        original_get_db = get_db
+        
+        async def mock_get_db_that_fails():
+            db_mock = await original_get_db()
+            
+            # Mock the update method to raise an exception
+            async def failing_update(*args, **kwargs):
+                raise Exception("Simulated database connection failure")
+                
+            db_mock.scanjob.update = failing_update
+            return db_mock
+        
+        # Create a test result that would normally trigger completion
+        test_result = {
+            "scan_completed_at": datetime.now().isoformat(),
+            "repository": test_job_data["repo_url"],
+            "branch": test_job_data["branch"],
+            "results": {
+                "summary": "Test scan completed",
+                "vulnerabilities": [],
+                "vulnerability_count": 0
+            },
+            "vulnerabilities_stored": 0
+        }
+        
+        # Test the process_job method with mocked database failure
+        with patch('scan_agent.workers.scanner.get_db', side_effect=mock_get_db_that_fails):
+            try:
+                worker.process_job(job)
+                print("❌ ERROR: process_job should have failed but didn't!")
+                return False
+            except Exception as e:
+                print(f"✅ Expected exception caught: {e}")
+        
+        # Check that Redis status is NOT marked as completed
+        redis_job = job_queue.get_job(job_id)
+        redis_status = redis_job.status.value if redis_job else "NOT_FOUND"
+        print(f"🔍 Redis status after failed database update: {redis_status}")
+        
+        # Check database status is still IN_PROGRESS
+        await close_database()
+        await init_database()
+        db = await get_db()
+        db_job = await db.scanjob.find_unique(where={"id": job_id})
+        db_status = db_job.status if db_job else "NOT_FOUND"
+        print(f"🔍 Database status after failed update: {db_status}")
+        
+        # Verify both are still IN_PROGRESS (synchronized)
+        if redis_status == "IN_PROGRESS" and db_status == "IN_PROGRESS":
+            print("✅ SUCCESS: Both Redis and Database remain IN_PROGRESS when database update fails")
+            return True
+        else:
+            print(f"❌ FAILURE: Status mismatch - Redis: {redis_status}, Database: {db_status}")
+            return False
+            
+    finally:
+        # Cleanup: remove test job
+        try:
+            await db.scanjob.delete(where={"id": job_id})
+            job_queue.redis.hdel(job_queue.jobs_key, job_id)
+            print(f"🧹 Cleaned up test job: {job_id}")
+        except Exception as e:
+            print(f"⚠️  Cleanup warning: {e}")
+            
+        await close_database()
+
+
+async def test_successful_completion():
+    """Test that both Redis and database get updated when everything works."""
+    print("\n🧪 Testing successful completion...")
+    
+    # Create a test job
+    job_queue = JobQueue()
+    
+    test_job_data = {
+        "repo_url": "https://github.com/test/repo.git", 
+        "branch": "main",
+        "claude_cli_args": None,
+        "scan_options": {}
+    }
+    
+    job_id = job_queue.add_job(JobType.SCAN_REPO, test_job_data)
+    print(f"📝 Created test job: {job_id}")
+    
+    # Initialize database connection
+    await init_database()
+    db = await get_db()
+    
+    try:
+        # Create ScanJob record in database
+        await db.scanjob.create(
+            data={
+                "id": job_id,
+                "type": "SCAN_REPO", 
+                "status": "IN_PROGRESS",
+                "startedAt": datetime.now(),
+                "data": json.dumps(test_job_data),
+            }
+        )
+        
+        # Simulate successful completion by directly calling the queue methods
+        test_result = {
+            "scan_completed_at": datetime.now().isoformat(),
+            "repository": test_job_data["repo_url"],
+            "branch": test_job_data["branch"],
+            "results": {"summary": "Test completed successfully"},
+            "vulnerabilities_stored": 0
+        }
+        
+        # Update database first (simulating successful database update)
+        await db.scanjob.update(
+            where={"id": job_id},
+            data={
+                "status": "COMPLETED",
+                "finishedAt": datetime.now(),
+                "result": json.dumps(test_result, default=str)
+            }
+        )
+        
+        # Then update Redis (this would happen in process_job after successful _process_scan_job)
+        job_queue.complete_job(job_id, test_result)
+        
+        # Verify both are synchronized
+        redis_job = job_queue.get_job(job_id)
+        redis_status = redis_job.status.value if redis_job else "NOT_FOUND"
+        
+        db_job = await db.scanjob.find_unique(where={"id": job_id})
+        db_status = db_job.status if db_job else "NOT_FOUND"
+        
+        print(f"🔍 Redis status after successful completion: {redis_status}")
+        print(f"🔍 Database status after successful completion: {db_status}")
+        
+        if redis_status == "COMPLETED" and db_status == "COMPLETED":
+            print("✅ SUCCESS: Both Redis and Database show COMPLETED when update succeeds")
+            return True
+        else:
+            print(f"❌ FAILURE: Status mismatch - Redis: {redis_status}, Database: {db_status}")
+            return False
+            
+    finally:
+        # Cleanup
+        try:
+            await db.scanjob.delete(where={"id": job_id})
+            job_queue.redis.hdel(job_queue.jobs_key, job_id)
+            print(f"🧹 Cleaned up test job: {job_id}")
+        except Exception as e:
+            print(f"⚠️  Cleanup warning: {e}")
+            
+        await close_database()
+
+
+async def main():
+    """Main test function."""
+    print("🚀 Job Status Synchronization Test Suite")
+    print("=" * 50)
+    
+    # Test 1: Database failure handling
+    test1_passed = await test_database_failure_handling()
+    
+    # Test 2: Successful completion
+    test2_passed = await test_successful_completion()
+    
+    # Summary
+    print(f"\n{'='*50}")
+    print("📊 Test Results:")
+    print(f"   Database Failure Handling: {'✅ PASSED' if test1_passed else '❌ FAILED'}")
+    print(f"   Successful Completion: {'✅ PASSED' if test2_passed else '❌ FAILED'}")
+    
+    if test1_passed and test2_passed:
+        print("\n🎉 All tests passed! Job status synchronization fix is working correctly.")
+    else:
+        print("\n❌ Some tests failed. Please review the implementation.")
+        
+    return test1_passed and test2_passed
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
Synchronize scan job statuses by preventing Redis completion updates when database updates fail.

Previously, a database update failure during scan job completion was silently caught and logged. This allowed the job to be marked as `COMPLETED` in Redis (which the frontend reads), while the database record remained `IN_PROGRESS`, leading to status discrepancies. Re-raising the exception now ensures that if the database update fails, the Redis status is also not updated, maintaining consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-97893b6d-0aa6-4ee6-96eb-c0efa3f6e5c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97893b6d-0aa6-4ee6-96eb-c0efa3f6e5c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

