### PR TITLE
Show branch and path in scan overview

### DIFF
--- a/frontend/src/app/api/scans/by-repo/[owner]/[repo]/route.ts
+++ b/frontend/src/app/api/scans/by-repo/[owner]/[repo]/route.ts
@@ -32,6 +32,15 @@ export async function GET(
             category: true,
           },
         },
+        scanTarget: {
+          select: {
+            id: true,
+            name: true,
+            repoUrl: true,
+            branch: true,
+            subPath: true,
+          },
+        },
       },
       orderBy: {
         createdAt: "desc",
@@ -74,6 +83,7 @@ export async function GET(
         vulnerabilityCounts,
         categoryCounts,
         totalVulnerabilities: scan.vulnerabilities.length,
+        scanTarget: scan.scanTarget,
       };
     });
 

--- a/frontend/src/app/projects/[id]/scans/page.tsx
+++ b/frontend/src/app/projects/[id]/scans/page.tsx
@@ -16,7 +16,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   Calendar,
   Clock,
-  FileText,
   GitBranch,
   Shield,
   Target,
@@ -170,6 +169,26 @@ export default function ProjectScansPage() {
     }
   };
 
+  const getBranchAndPath = (scan: ProcessedScan) => {
+    // Use scanTarget data if available
+    if (scan.scanTarget) {
+      return {
+        branch: scan.scanTarget.branch,
+        subPath: scan.scanTarget.subPath !== "/" ? scan.scanTarget.subPath : null,
+      };
+    }
+    
+    // Fallback to extracting from scan.data
+    if (scan.data) {
+      return {
+        branch: scan.data.branch || scan.data.ref || "main",
+        subPath: scan.data.sub_path && scan.data.sub_path !== "/" ? scan.data.sub_path : null,
+      };
+    }
+    
+    return { branch: "main", subPath: null };
+  };
+
   if (loading) {
     return (
       <div className="space-y-6">
@@ -244,18 +263,14 @@ export default function ProjectScansPage() {
                                   <Calendar className="h-3 w-3" />
                                   {formatDate(scan.createdAt)}
                                 </span>
-                                {scan.scanTarget && (
-                                  <>
-                                    <span className="flex items-center gap-1">
-                                      <GitBranch className="h-3 w-3" />
-                                      {scan.scanTarget.branch}
-                                    </span>
-                                    {scan.scanTarget.subPath !== "/" && (
-                                      <span className="text-xs bg-muted px-2 py-1 rounded">
-                                        {scan.scanTarget.subPath}
-                                      </span>
-                                    )}
-                                  </>
+                                <span className="flex items-center gap-1">
+                                  <GitBranch className="h-3 w-3" />
+                                  {getBranchAndPath(scan).branch}
+                                </span>
+                                {getBranchAndPath(scan).subPath && (
+                                  <span className="text-xs bg-muted px-2 py-1 rounded">
+                                    {getBranchAndPath(scan).subPath}
+                                  </span>
                                 )}
                                 {scan.finishedAt && scan.startedAt && (
                                   <span className="flex items-center gap-1">

--- a/frontend/src/app/scans/[owner]/[repo]/page.tsx
+++ b/frontend/src/app/scans/[owner]/[repo]/page.tsx
@@ -28,6 +28,14 @@ import {
   StopCircle,
 } from "lucide-react";
 
+interface ScanTarget {
+  id: string;
+  name: string;
+  repoUrl: string;
+  branch: string;
+  subPath: string;
+}
+
 interface ScanJobSummary {
   id: string;
   type: string;
@@ -48,6 +56,7 @@ interface ScanJobSummary {
   };
   categoryCounts: Record<string, number>;
   totalVulnerabilities: number;
+  scanTarget: ScanTarget | null;
 }
 
 interface RepositorySummary {
@@ -172,6 +181,26 @@ function RepositoryScansContent({
     const minutes = Math.floor(diff / 60000);
     const seconds = Math.floor((diff % 60000) / 1000);
     return `${minutes}m ${seconds}s`;
+  };
+
+  const getBranchAndPath = (scan: ScanJobSummary) => {
+    // Use scanTarget data if available
+    if (scan.scanTarget) {
+      return {
+        branch: scan.scanTarget.branch,
+        subPath: scan.scanTarget.subPath !== "/" ? scan.scanTarget.subPath : null,
+      };
+    }
+    
+    // Fallback to extracting from scan.data
+    if (scan.data) {
+      return {
+        branch: scan.data.branch || scan.data.ref || "main",
+        subPath: scan.data.sub_path && scan.data.sub_path !== "/" ? scan.data.sub_path : null,
+      };
+    }
+    
+    return { branch: "main", subPath: null };
   };
 
   const cancelScan = async (scanId: string) => {
@@ -402,12 +431,23 @@ function RepositoryScansContent({
                         </Badge>
                       </CardTitle>
                       <CardDescription className="text-gray-300 text-sm">
-                        <div className="flex items-center gap-4">
+                        <div className="flex items-center gap-4 mb-2">
                           <span>Started: {formatDate(scan.createdAt)}</span>
                           {scan.finishedAt && (
                             <span>
                               Duration:{" "}
                               {formatDuration(scan.startedAt, scan.finishedAt)}
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                          <span className="flex items-center gap-1">
+                            <GitBranch className="h-3 w-3" />
+                            {getBranchAndPath(scan).branch}
+                          </span>
+                          {getBranchAndPath(scan).subPath && (
+                            <span className="bg-muted px-2 py-1 rounded">
+                              {getBranchAndPath(scan).subPath}
                             </span>
                           )}
                         </div>


### PR DESCRIPTION
Add branch and path information to scan overview pages for improved context.

---
<a href="https://cursor.com/background-agent?bcId=bc-99b12ba0-9d4d-4f22-a779-15c2e81dcb75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99b12ba0-9d4d-4f22-a779-15c2e81dcb75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

