### PR TITLE
Fix job cancellation enum error

### DIFF
--- a/fix-cancel-job-issue.md
+++ b/fix-cancel-job-issue.md
@@ -1,0 +1,92 @@
+# Fix for Job Cancellation Error
+
+## Problem
+When clicking "Cancel" on a scan job, you're getting this error:
+```
+Error [PrismaClientUnknownRequestError]: invalid input value for enum "JobStatus": "CANCELLED"
+```
+
+## Root Cause
+The database schema doesn't have the `CANCELLED` value in the `JobStatus` enum, even though:
+1. The migration file `20250909044604_add_cancelled_job_status/migration.sql` exists
+2. The Prisma schema defines `CANCELLED` in the `JobStatus` enum
+3. The frontend and backend code correctly handle job cancellation
+
+This indicates the migration hasn't been applied to the actual database.
+
+## Solution
+
+### Option 1: Run Database Migration (Recommended)
+1. **Start your database** (if not already running):
+   ```bash
+   cd /workspace
+   docker compose up -d postgres
+   ```
+
+2. **Set environment variables and run migration**:
+   ```bash
+   export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/fortify"
+   export POSTGRES_PRISMA_URL="postgresql://postgres:postgres@localhost:5432/fortify" 
+   export POSTGRES_URL_NON_POOLING="postgresql://postgres:postgres@localhost:5432/fortify"
+   
+   cd db
+   npx prisma migrate deploy
+   ```
+
+### Option 2: Manual Database Fix
+If the migration doesn't work, you can manually add the enum value:
+
+1. **Connect to PostgreSQL**:
+   ```bash
+   docker exec -it postgres psql -U postgres -d fortify
+   ```
+
+2. **Run the SQL command**:
+   ```sql
+   ALTER TYPE "JobStatus" ADD VALUE 'CANCELLED';
+   ```
+
+3. **Verify the fix**:
+   ```sql
+   SELECT e.enumlabel as value
+   FROM pg_enum e 
+   JOIN pg_type t ON e.enumtypid = t.oid 
+   WHERE t.typname = 'JobStatus'
+   ORDER BY e.enumsortorder;
+   ```
+
+   You should see: `PENDING`, `IN_PROGRESS`, `COMPLETED`, `FAILED`, `CANCELLED`
+
+4. **Exit PostgreSQL**:
+   ```sql
+   \q
+   ```
+
+### Option 3: Using the Fix Script
+I've created a Python script that can automatically fix this:
+
+```bash
+cd /workspace
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/fortify"
+python3 fix_cancelled_enum.py
+```
+
+## Verification
+After applying the fix:
+
+1. **Try cancelling a job** - the error should be gone
+2. **Check the job status** - it should show as "CANCELLED"
+3. **The frontend should display** the cancelled state properly
+
+## What the Fix Does
+The fix adds the `CANCELLED` value to the PostgreSQL enum type `JobStatus`, which allows the Prisma client to successfully update job records with this status.
+
+## Prevention
+To prevent this in the future:
+1. Always run `npx prisma migrate deploy` after pulling changes that include new migrations
+2. Check migration status with `npx prisma migrate status` before deploying
+3. Ensure environment variables are set correctly for database connections
+
+## Files Created
+- `fix_cancelled_enum.py` - Python script to automatically fix the enum
+- `fix-cancelled-enum.sql` - Raw SQL script for manual application

--- a/fix-cancel-job.sh
+++ b/fix-cancel-job.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Fix for Job Cancellation Error
+# This script fixes the missing CANCELLED enum value in the JobStatus enum
+
+echo "🔧 Fixing CANCELLED enum value in JobStatus..."
+echo "=" * 50
+
+# Set database connection environment variables
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/fortify"
+export POSTGRES_PRISMA_URL="postgresql://postgres:postgres@localhost:5432/fortify" 
+export POSTGRES_URL_NON_POOLING="postgresql://postgres:postgres@localhost:5432/fortify"
+
+echo "✅ Database environment variables set"
+
+# Check if PostgreSQL is running
+echo "🔍 Checking if PostgreSQL is running..."
+if ! docker ps | grep -q postgres; then
+    echo "⚠️  PostgreSQL container not running, starting it..."
+    docker compose up -d postgres
+    echo "⏳ Waiting for PostgreSQL to start..."
+    sleep 5
+else
+    echo "✅ PostgreSQL is running"
+fi
+
+# Method 1: Try to run pending migrations
+echo ""
+echo "🔄 Attempting to apply database migrations..."
+cd db
+if npx prisma migrate deploy 2>/dev/null; then
+    echo "✅ Database migrations applied successfully"
+    success=true
+else
+    echo "⚠️  Migration deploy failed, trying manual fix..."
+    success=false
+fi
+
+# Method 2: Manual enum fix if migration failed
+if [ "$success" = false ]; then
+    echo ""
+    echo "🔧 Applying manual fix..."
+    
+    # Use Docker to run the SQL command directly
+    docker exec -i postgres psql -U postgres -d fortify << 'EOF'
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum e 
+        JOIN pg_type t ON e.enumtypid = t.oid 
+        WHERE t.typname = 'JobStatus' AND e.enumlabel = 'CANCELLED'
+    ) THEN
+        ALTER TYPE "JobStatus" ADD VALUE 'CANCELLED';
+        RAISE NOTICE 'Added CANCELLED value to JobStatus enum';
+    ELSE
+        RAISE NOTICE 'CANCELLED value already exists in JobStatus enum';
+    END IF;
+END
+$$;
+EOF
+    
+    if [ $? -eq 0 ]; then
+        echo "✅ Manual fix applied successfully"
+        success=true
+    else
+        echo "❌ Manual fix failed"
+    fi
+fi
+
+# Verify the fix
+if [ "$success" = true ]; then
+    echo ""
+    echo "🔍 Verifying the fix..."
+    docker exec -i postgres psql -U postgres -d fortify -t << 'EOF'
+SELECT e.enumlabel as value
+FROM pg_enum e 
+JOIN pg_type t ON e.enumtypid = t.oid 
+WHERE t.typname = 'JobStatus'
+ORDER BY e.enumsortorder;
+EOF
+    
+    echo ""
+    echo "🎉 Fix completed successfully!"
+    echo "✅ You can now try cancelling jobs again."
+    echo ""
+    echo "To test:"
+    echo "1. Go to https://fortify.rocks/jobs/cmffvrnh30001brcy4wqw4ycj"
+    echo "2. Click 'Cancel Scan'"
+    echo "3. The job should be cancelled without errors"
+    
+else
+    echo ""
+    echo "❌ Fix failed. Please:"
+    echo "1. Check that PostgreSQL is running: docker compose ps"
+    echo "2. Check database connectivity"
+    echo "3. Try the manual steps in fix-cancel-job-issue.md"
+    exit 1
+fi

--- a/fix-cancelled-enum.sql
+++ b/fix-cancelled-enum.sql
@@ -1,0 +1,20 @@
+-- Fix for missing CANCELLED enum value in JobStatus
+-- This script adds CANCELLED to the JobStatus enum if it doesn't already exist
+
+-- Check if CANCELLED value already exists, if not, add it
+DO $$
+BEGIN
+    -- Check if the enum value already exists
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum e 
+        JOIN pg_type t ON e.enumtypid = t.oid 
+        WHERE t.typname = 'JobStatus' AND e.enumlabel = 'CANCELLED'
+    ) THEN
+        -- Add the CANCELLED value to the JobStatus enum
+        ALTER TYPE "JobStatus" ADD VALUE 'CANCELLED';
+        RAISE NOTICE 'Added CANCELLED value to JobStatus enum';
+    ELSE
+        RAISE NOTICE 'CANCELLED value already exists in JobStatus enum';
+    END IF;
+END
+$$;

--- a/fix_cancelled_enum.py
+++ b/fix_cancelled_enum.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Script to fix the missing CANCELLED enum value in the JobStatus enum.
+This addresses the error: invalid input value for enum "JobStatus": "CANCELLED"
+"""
+
+import os
+import sys
+import asyncio
+import asyncpg
+
+async def fix_cancelled_enum():
+    """Add CANCELLED value to JobStatus enum if it doesn't exist."""
+    
+    # Get database URL from environment or use default
+    database_url = os.getenv('DATABASE_URL', 'postgresql://postgres:postgres@localhost:5432/fortify')
+    
+    print(f"Connecting to database...")
+    print(f"Database URL: {database_url}")
+    
+    try:
+        # Connect to the database
+        conn = await asyncpg.connect(database_url)
+        print("✅ Connected to database successfully")
+        
+        # Check if CANCELLED value already exists in JobStatus enum
+        check_query = """
+        SELECT EXISTS (
+            SELECT 1 FROM pg_enum e 
+            JOIN pg_type t ON e.enumtypid = t.oid 
+            WHERE t.typname = 'JobStatus' AND e.enumlabel = 'CANCELLED'
+        ) as cancelled_exists
+        """
+        
+        result = await conn.fetchrow(check_query)
+        cancelled_exists = result['cancelled_exists']
+        
+        if cancelled_exists:
+            print("ℹ️  CANCELLED value already exists in JobStatus enum")
+        else:
+            print("⚠️  CANCELLED value missing from JobStatus enum, adding it...")
+            
+            # Add CANCELLED to the JobStatus enum
+            alter_query = 'ALTER TYPE "JobStatus" ADD VALUE \'CANCELLED\''
+            await conn.execute(alter_query)
+            
+            print("✅ Successfully added CANCELLED value to JobStatus enum")
+        
+        # Verify the fix by checking all enum values
+        verify_query = """
+        SELECT e.enumlabel as value
+        FROM pg_enum e 
+        JOIN pg_type t ON e.enumtypid = t.oid 
+        WHERE t.typname = 'JobStatus'
+        ORDER BY e.enumsortorder
+        """
+        
+        enum_values = await conn.fetch(verify_query)
+        print(f"\nCurrent JobStatus enum values:")
+        for row in enum_values:
+            print(f"  - {row['value']}")
+        
+        await conn.close()
+        print("\n✅ Database connection closed")
+        print("✅ Fix completed successfully!")
+        
+        return True
+        
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        return False
+
+async def main():
+    """Main function."""
+    print("🔧 Fixing CANCELLED enum value in JobStatus...")
+    print("=" * 50)
+    
+    success = await fix_cancelled_enum()
+    
+    if success:
+        print("\n🎉 All done! The CANCELLED enum value should now be available.")
+        print("You can now try cancelling jobs again.")
+        sys.exit(0)
+    else:
+        print("\n❌ Fix failed. Please check the error messages above.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Add scripts and documentation to resolve the 'CANCELLED' JobStatus enum missing from the database.

The database was missing the `CANCELLED` value in the `JobStatus` enum, despite it being defined in the Prisma schema and migrations. This PR provides automated scripts and manual instructions to add this missing enum value, fixing the internal server error encountered when cancelling jobs.

---
<a href="https://cursor.com/background-agent?bcId=bc-d410b7bf-2b25-4c0d-9152-9134b711da7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d410b7bf-2b25-4c0d-9152-9134b711da7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

