### PR TITLE
Fix vulnerability page theme color

### DIFF
--- a/frontend/src/app/vulnerabilities/[scanId]/page.tsx
+++ b/frontend/src/app/vulnerabilities/[scanId]/page.tsx
@@ -70,11 +70,11 @@ interface Pagination {
 }
 
 const severityColors = {
-  CRITICAL: "bg-red-500 text-white",
-  HIGH: "bg-orange-500 text-white",
-  MEDIUM: "bg-yellow-500 text-black",
-  LOW: "bg-blue-500 text-white",
-  INFO: "bg-gray-500 text-white",
+  CRITICAL: "text-red-400",
+  HIGH: "text-orange-400", 
+  MEDIUM: "text-yellow-400",
+  LOW: "text-blue-400",
+  INFO: "text-gray-400",
 };
 
 const categoryLabels: Record<string, string> = {
@@ -262,7 +262,7 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
             <h2 className="text-2xl font-bold mb-4">
               Error Loading Vulnerabilities
             </h2>
-            <p className="text-gray-300 mb-6">{error}</p>
+            <p className="text-muted-foreground mb-6">{error}</p>
             <Button
               onClick={() => fetchVulnerabilities(currentPage)}
               className="mr-4"
@@ -292,7 +292,7 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
                 Vulnerabilities
               </h1>
               {scanJob && (
-                <p className="text-gray-400">
+                <p className="text-muted-foreground">
                   Scan from {formatDate(scanJob.createdAt)} •{" "}
                   {scanJob.data?.repo || "Repository"}
                 </p>
@@ -317,11 +317,11 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
         {/* Summary Cards */}
         {summary && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-            <Card className="bg-gray-800 border-gray-700">
+            <Card className="bg-card border-border">
               <CardContent className="p-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm text-gray-400">Total Issues</p>
+                    <p className="text-sm text-muted-foreground">Total Issues</p>
                     <p className="text-2xl font-bold">
                       {summary.totalVulnerabilities}
                     </p>
@@ -331,11 +331,11 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
               </CardContent>
             </Card>
 
-            <Card className="bg-gray-800 border-gray-700">
+            <Card className="bg-card border-border">
               <CardContent className="p-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm text-gray-400">Critical</p>
+                    <p className="text-sm text-muted-foreground">Critical</p>
                     <p className="text-2xl font-bold text-red-400">
                       {summary.severityCounts.CRITICAL || 0}
                     </p>
@@ -345,11 +345,11 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
               </CardContent>
             </Card>
 
-            <Card className="bg-gray-800 border-gray-700">
+            <Card className="bg-card border-border">
               <CardContent className="p-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm text-gray-400">High</p>
+                    <p className="text-sm text-muted-foreground">High</p>
                     <p className="text-2xl font-bold text-orange-400">
                       {summary.severityCounts.HIGH || 0}
                     </p>
@@ -359,11 +359,11 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
               </CardContent>
             </Card>
 
-            <Card className="bg-gray-800 border-gray-700">
+            <Card className="bg-card border-border">
               <CardContent className="p-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm text-gray-400">Affected Files</p>
+                    <p className="text-sm text-muted-foreground">Affected Files</p>
                     <p className="text-2xl font-bold">
                       {summary.topFiles.length}
                     </p>
@@ -376,7 +376,7 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
         )}
 
         {/* Filters */}
-        <Card className="bg-gray-800 border-gray-700 mb-8">
+        <Card className="bg-card border-border mb-8">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Filter className="h-5 w-5" />
@@ -386,19 +386,19 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   placeholder="Search vulnerabilities..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 bg-gray-700 border-gray-600 text-white"
+                  className="pl-10"
                 />
               </div>
 
               <select
                 value={selectedSeverity}
                 onChange={(e) => setSelectedSeverity(e.target.value)}
-                className="px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
+                className="px-3 py-2 bg-input border border-border rounded-md text-foreground"
               >
                 <option value="">All Severities</option>
                 <option value="CRITICAL">Critical</option>
@@ -411,7 +411,7 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
               <select
                 value={selectedCategory}
                 onChange={(e) => setSelectedCategory(e.target.value)}
-                className="px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
+                className="px-3 py-2 bg-input border border-border rounded-md text-foreground"
               >
                 <option value="">All Categories</option>
                 {Object.entries(categoryLabels).map(([value, label]) => (
@@ -424,7 +424,7 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
               <select
                 value={selectedFile}
                 onChange={(e) => setSelectedFile(e.target.value)}
-                className="px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white"
+                className="px-3 py-2 bg-input border border-border rounded-md text-foreground"
               >
                 <option value="">All Files</option>
                 {summary?.topFiles.map((file) => (
@@ -453,7 +453,7 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
         {/* Pagination */}
         {pagination && pagination.totalPages > 1 && (
           <div className="flex justify-between items-center mt-8">
-            <div className="text-sm text-gray-400">
+            <div className="text-sm text-muted-foreground">
               Showing {(pagination.page - 1) * pagination.limit + 1} to{" "}
               {Math.min(
                 pagination.page * pagination.limit,
@@ -491,7 +491,7 @@ function VulnerabilitiesContent({ scanId }: { scanId: string }) {
             <h2 className="text-xl font-semibold mb-2">
               No Vulnerabilities Found
             </h2>
-            <p className="text-gray-400 text-lg">
+            <p className="text-muted-foreground text-lg">
               {vulnerabilities.length === 0
                 ? "Great! This scan didn't find any security vulnerabilities."
                 : "No vulnerabilities match your current filters."}

--- a/frontend/src/components/vulnerability/VulnerabilityCard.tsx
+++ b/frontend/src/components/vulnerability/VulnerabilityCard.tsx
@@ -60,11 +60,11 @@ const FIXABLE_CATEGORIES = [
 ];
 
 const severityColors = {
-  CRITICAL: "bg-red-500 text-white",
-  HIGH: "bg-orange-500 text-white",
-  MEDIUM: "bg-yellow-500 text-black",
-  LOW: "bg-blue-500 text-white",
-  INFO: "bg-gray-500 text-white",
+  CRITICAL: "text-red-400",
+  HIGH: "text-orange-400", 
+  MEDIUM: "text-yellow-400",
+  LOW: "text-blue-400",
+  INFO: "text-gray-400",
 };
 
 const categoryLabels: Record<string, string> = {
@@ -273,10 +273,11 @@ export function VulnerabilityCard({
           <div className="flex-1 pr-16">
             {" "}
             {/* Add padding to prevent overlap with fix button */}
-            <CardTitle className="text-lg text-white mb-2 flex items-center gap-2">
+            <CardTitle className="text-lg text-foreground mb-2 flex items-center gap-2">
               <AlertCircle className="h-5 w-5" />
               {vulnerability.title}
               <Badge
+                variant="outline"
                 className={
                   severityColors[
                     vulnerability.severity as keyof typeof severityColors
@@ -290,7 +291,7 @@ export function VulnerabilityCard({
                   vulnerability.category}
               </Badge>
             </CardTitle>
-            <CardDescription className="text-gray-300 text-sm flex items-center gap-4">
+            <CardDescription className="text-muted-foreground text-sm flex items-center gap-4">
               <span className="flex items-center gap-1">
                 <FileText className="h-4 w-4" />
                 {truncateFilePath(vulnerability.filePath)}
@@ -312,17 +313,17 @@ export function VulnerabilityCard({
           <div className="space-y-4">
             {/* Description */}
             <div>
-              <h4 className="font-semibold text-white mb-2">Description</h4>
-              <p className="text-gray-300 text-sm">
+              <h4 className="font-semibold text-foreground mb-2">Description</h4>
+              <p className="text-muted-foreground text-sm">
                 {vulnerability.description}
               </p>
             </div>
 
             {/* Code Snippet */}
             <div>
-              <h4 className="font-semibold text-white mb-2">Code Snippet</h4>
-              <pre className="bg-gray-900 p-4 rounded-lg overflow-x-auto text-sm">
-                <code className="text-gray-300">
+              <h4 className="font-semibold text-foreground mb-2">Code Snippet</h4>
+              <pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm">
+                <code className="text-muted-foreground">
                   {vulnerability.codeSnippet}
                 </code>
               </pre>
@@ -330,8 +331,8 @@ export function VulnerabilityCard({
 
             {/* Recommendation */}
             <div>
-              <h4 className="font-semibold text-white mb-2">Recommendation</h4>
-              <p className="text-gray-300 text-sm">
+              <h4 className="font-semibold text-foreground mb-2">Recommendation</h4>
+              <p className="text-muted-foreground text-sm">
                 {vulnerability.recommendation}
               </p>
             </div>
@@ -340,7 +341,7 @@ export function VulnerabilityCard({
             {vulnerability.metadata &&
               Object.keys(vulnerability.metadata).length > 0 && (
                 <div>
-                  <h4 className="font-semibold text-white mb-2">
+                  <h4 className="font-semibold text-foreground mb-2">
                     Additional Information
                   </h4>
                   <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
Improve color consistency on the vulnerability page and cards by aligning styles with the Fortify platform theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0ab2706-6bac-432b-8a96-0dc45b2afad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0ab2706-6bac-432b-8a96-0dc45b2afad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

