### PR TITLE
Fix invalid startedat date format

### DIFF
--- a/scan-agent/fix_agent/workers/fixer.py
+++ b/scan-agent/fix_agent/workers/fixer.py
@@ -1725,7 +1725,7 @@ Please review the changes and run your test suite to ensure the fix doesn't brea
                 data={
                     "status": "COMPLETED",
                     "result": json.dumps(result_data),
-                    "finishedAt": datetime.now().isoformat(),
+                    "finishedAt": datetime.now().isoformat() + "Z",
                     "branchName": result.branchName,
                     "commitSha": result.commitSha,
                     "pullRequestUrl": result.pullRequestUrl,
@@ -1754,7 +1754,7 @@ Please review the changes and run your test suite to ensure the fix doesn't brea
                 data={
                     "status": "FAILED",
                     "error": error_msg,
-                    "finishedAt": datetime.now().isoformat(),
+                    "finishedAt": datetime.now().isoformat() + "Z",
                 },
             )
             logger.info(f"✅ Updated FixJob {job_id} status to FAILED in database")
@@ -1778,7 +1778,7 @@ Please review the changes and run your test suite to ensure the fix doesn't brea
                 where={"id": job_id},
                 data={
                     "status": "IN_PROGRESS",
-                    "startedAt": datetime.now().isoformat(),
+                    "startedAt": datetime.now().isoformat() + "Z",
                 },
             )
             logger.info(f"✅ Updated FixJob {job_id} status to IN_PROGRESS in database")

--- a/scan-agent/scan_agent/workers/scanner.py
+++ b/scan-agent/scan_agent/workers/scanner.py
@@ -1249,7 +1249,7 @@ Please begin the security audit now."""
                     data={
                         "status": "COMPLETED",
                         "result": json.dumps(result),
-                        "finishedAt": datetime.now().isoformat(),
+                        "finishedAt": datetime.now().isoformat() + "Z",
                         "vulnerabilitiesFound": result.get("vulnerabilities_stored", 0),
                     },
                 )
@@ -1292,7 +1292,7 @@ Please begin the security audit now."""
                 data={
                     "status": "FAILED",
                     "error": error_msg,
-                    "finishedAt": datetime.now().isoformat(),
+                    "finishedAt": datetime.now().isoformat() + "Z",
                 },
             )
             logger.info(f"Updated ScanJob {job_id} status to FAILED")


### PR DESCRIPTION
Append 'Z' to ISO-formatted datetime strings to resolve Prisma database errors caused by missing timezone indicators.

The `datetime.now().isoformat()` method produces a string without a timezone (e.g., `2025-09-12T01:54:28.383866`). Prisma, however, requires a full ISO-8601 datetime string including a timezone indicator (e.g., `2025-09-12T01:54:28.383866Z`). Without the 'Z' (indicating UTC), Prisma rejects the input with an "Invalid argument value... premature end of input" error, preventing `FixJob` and `ScanJob` status updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-952a2dcd-8cb2-4f2a-b8ac-c1210c42f746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-952a2dcd-8cb2-4f2a-b8ac-c1210c42f746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

