### PR TITLE
Fix datetime parsing for failed fix jobs

### DIFF
--- a/scan-agent/fix_agent/workers/fixer.py
+++ b/scan-agent/fix_agent/workers/fixer.py
@@ -1725,7 +1725,7 @@ Please review the changes and run your test suite to ensure the fix doesn't brea
                 data={
                     "status": "COMPLETED",
                     "result": json.dumps(result_data),
-                    "finishedAt": datetime.now().isoformat(),
+                    "finishedAt": datetime.now().isoformat() + "Z",
                     "branchName": result.branchName,
                     "commitSha": result.commitSha,
                     "pullRequestUrl": result.pullRequestUrl,
@@ -1754,7 +1754,7 @@ Please review the changes and run your test suite to ensure the fix doesn't brea
                 data={
                     "status": "FAILED",
                     "error": error_msg,
-                    "finishedAt": datetime.now().isoformat(),
+                    "finishedAt": datetime.now().isoformat() + "Z",
                 },
             )
             logger.info(f"✅ Updated FixJob {job_id} status to FAILED in database")
@@ -1778,7 +1778,7 @@ Please review the changes and run your test suite to ensure the fix doesn't brea
                 where={"id": job_id},
                 data={
                     "status": "IN_PROGRESS",
-                    "startedAt": datetime.now().isoformat(),
+                    "startedAt": datetime.now().isoformat() + "Z",
                 },
             )
             logger.info(f"✅ Updated FixJob {job_id} status to IN_PROGRESS in database")

--- a/scan-agent/scan_agent/workers/scanner.py
+++ b/scan-agent/scan_agent/workers/scanner.py
@@ -1195,7 +1195,7 @@ Please begin the security audit now."""
             logger.info("Step 3: Processing scan results")
             print("📊 Step 3: Processing scan results...")
             result = {
-                "scan_completed_at": datetime.now().isoformat(),
+                "scan_completed_at": datetime.now().isoformat() + "Z",
                 "repository": scan_data.repo_url,
                 "branch": scan_data.branch,
                 "results": scan_results,
@@ -1249,7 +1249,7 @@ Please begin the security audit now."""
                     data={
                         "status": "COMPLETED",
                         "result": json.dumps(result),
-                        "finishedAt": datetime.now().isoformat(),
+                        "finishedAt": datetime.now().isoformat() + "Z",
                         "vulnerabilitiesFound": result.get("vulnerabilities_stored", 0),
                     },
                 )
@@ -1292,7 +1292,7 @@ Please begin the security audit now."""
                 data={
                     "status": "FAILED",
                     "error": error_msg,
-                    "finishedAt": datetime.now().isoformat(),
+                    "finishedAt": datetime.now().isoformat() + "Z",
                 },
             )
             logger.info(f"Updated ScanJob {job_id} status to FAILED")


### PR DESCRIPTION
Fix Prisma datetime validation by appending 'Z' (UTC timezone) to `isoformat()` outputs.

`datetime.now().isoformat()` does not include timezone information, which caused Prisma to reject datetime strings with a "premature end of input" error. Appending 'Z' ensures the generated datetime strings are valid ISO-8601 with UTC timezone.

---
<a href="https://cursor.com/background-agent?bcId=bc-5795b7be-79e8-4190-bce0-669f6fc3fb6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5795b7be-79e8-4190-bce0-669f6fc3fb6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

